### PR TITLE
feat(oci): support OCI version tags in source

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ spec:
   params:
     annotations:
       config.kubernetes.io/local-config: "true"
-  source: oci://ghcr.io/kcl-lang/set-annotation
+  source: oci://ghcr.io/kcl-lang/set-annotations:0.1.1
   credentials: # If private OCI registry
     url: https://<oci-host-url> # or KCL_SRC_URL environment variable
     username: <username> # or KCL_SRC_USERNAME environment variable
@@ -101,7 +101,7 @@ spec:
   params:
     annotations:
       config.kubernetes.io/local-config: "true"
-  source: oci://localhost:7900/my-repo/set-annotation
+  source: oci://ghcr.io/kcl-lang/set-annotations:0.1.1
 ```
 
 ## Resource Match Constraints
@@ -113,7 +113,7 @@ spec:
   params:
     annotations:
       config.kubernetes.io/local-config: "true"
-  source: oci://ghcr.io/kcl-lang/set-annotation
+  source: oci://ghcr.io/kcl-lang/set-annotation:0.1.1
   matchConstraints:  # Set resource filter match constraints for the matched types.
     resourceRules:
     - apiGroups: ["apps"]
@@ -130,7 +130,7 @@ spec:
   params:
     annotations:
       config.kubernetes.io/local-config: "true"
-  source: oci://ghcr.io/kcl-lang/set-annotation
+  source: oci://ghcr.io/kcl-lang/set-annotation:0.1.1
   config: # See [pkg/api/ConfigSpec]
     vendor: true
     sortKeys: true
@@ -146,7 +146,7 @@ kind: KCLRun
 spec:
   # Set the dependencies are the external dependencies for the KCL code.
   # The format of the `dependencies` field is same as the [dependencies]` in the `kcl.mod` file
-  dependencies:
+  dependencies: |
     k8s = "1.31"
   source: |
     import k8s.api.core.v1 as k8core

--- a/examples/mutation/oci-version/kcl.mod
+++ b/examples/mutation/oci-version/kcl.mod
@@ -1,0 +1,4 @@
+[package]
+name = "oci-version"
+edition = "*"
+version = "0.0.1"

--- a/examples/mutation/oci-version/main.k
+++ b/examples/mutation/oci-version/main.k
@@ -1,0 +1,6 @@
+params = option("params") or {}
+# Use `k = v` to override existing annotations
+annotations: {str:str} = {k = v for k, v in params.annotations or {}}
+items = [item | {
+    metadata.annotations: annotations
+} for item in option("items")]

--- a/examples/mutation/oci-version/suite/bad.yaml
+++ b/examples/mutation/oci-version/suite/bad.yaml
@@ -1,0 +1,25 @@
+apiVersion: krm.kcl.dev/v1alpha1
+kind: KCLRun
+metadata:
+  name: set-annotations
+  annotations:
+    krm.kcl.dev/version: 0.0.1
+    krm.kcl.dev/type: mutation
+    documentation: >-
+      Set annotations
+spec:
+  params:
+    annotations:
+      config.kubernetes.io/local-config: "true"
+  source: oci://ghcr.io/kcl-lang/set-annotations:0.0.0
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+spec:
+  containers:
+    - name: nginx
+      image: nginx:1.14.2
+      ports:
+        - containerPort: 80

--- a/examples/mutation/oci-version/suite/config.yaml
+++ b/examples/mutation/oci-version/suite/config.yaml
@@ -1,0 +1,9 @@
+apiVersion: krm.kcl.dev/v1alpha1
+kind: KCLRun
+metadata:
+  name: set-annotations
+spec:
+  params:
+    annotations:
+      config.kubernetes.io/local-config: "true"
+  source: oci://ghcr.io/kcl-lang/set-annotations:0.1.1

--- a/examples/mutation/oci-version/suite/good.yaml
+++ b/examples/mutation/oci-version/suite/good.yaml
@@ -1,0 +1,25 @@
+apiVersion: krm.kcl.dev/v1alpha1
+kind: KCLRun
+metadata:
+  name: set-annotations
+  annotations:
+    krm.kcl.dev/version: 0.0.1
+    krm.kcl.dev/type: mutation
+    documentation: >-
+      Set annotations
+spec:
+  params:
+    annotations:
+      config.kubernetes.io/local-config: "true"
+  source: oci://ghcr.io/kcl-lang/set-annotations:0.1.1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+spec:
+  containers:
+    - name: nginx
+      image: nginx:1.14.2
+      ports:
+        - containerPort: 80

--- a/pkg/options/run_test.go
+++ b/pkg/options/run_test.go
@@ -85,6 +85,20 @@ func TestRunOCI(t *testing.T) {
 			false,
 		},
 		{
+			"resource_list",
+			fields{
+				InputPath: "./testdata/resource_list/kcl-run-oci-with-version.yaml",
+			},
+			false,
+		},
+		{
+			"resource_list",
+			fields{
+				InputPath: "./testdata/resource_list/kcl-run-oci-with-bad-version.yaml",
+			},
+			true,
+		},
+		{
 			"yaml_stream",
 			fields{
 				InputPath: "./testdata/yaml_stream/kcl-run-oci.yaml",

--- a/pkg/options/testdata/resource_list/kcl-run-oci-with-bad-version.yaml
+++ b/pkg/options/testdata/resource_list/kcl-run-oci-with-bad-version.yaml
@@ -1,0 +1,15 @@
+apiVersion: config.kubernetes.io/v1
+kind: ResourceList
+items:
+  - apiVersion: apps/v1
+    kind: Deployment
+    spec:
+      replicas: 2
+functionConfig:
+  apiVersion: krm.kcl.dev/v1alpha1
+  kind: KCLRun
+  spec:
+    params:
+      annotations:
+        config.kubernetes.io/local-config: "true"
+    source: oci://ghcr.io/kcl-lang/set-annotations:0.0.0

--- a/pkg/options/testdata/resource_list/kcl-run-oci-with-version.yaml
+++ b/pkg/options/testdata/resource_list/kcl-run-oci-with-version.yaml
@@ -1,0 +1,15 @@
+apiVersion: config.kubernetes.io/v1
+kind: ResourceList
+items:
+  - apiVersion: apps/v1
+    kind: Deployment
+    spec:
+      replicas: 2
+functionConfig:
+  apiVersion: krm.kcl.dev/v1alpha1
+  kind: KCLRun
+  spec:
+    params:
+      annotations:
+        config.kubernetes.io/local-config: "true"
+    source: oci://ghcr.io/kcl-lang/set-annotations:0.1.1

--- a/pkg/source/oci.go
+++ b/pkg/source/oci.go
@@ -14,3 +14,12 @@ const (
 func IsOCI(src string) bool {
 	return strings.HasPrefix(src, fmt.Sprintf("%s://", OCIScheme))
 }
+
+// Trims the protocol prefix from an OCI URL
+func TrimOCIPrefix(src string) string {
+	return strings.TrimPrefix(src, fmt.Sprintf("%s://", OCIScheme))
+}
+
+func OCIPrefix(src string) string {
+	return fmt.Sprintf("%s://%s", OCIScheme, src)
+}


### PR DESCRIPTION
Add support for fetching a specific version of an OCI module using the syntax:

> source: oci://example.com/org/image:1.0.0

Fixes #147

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

#### 2. What is the scope of this PR (e.g. component or file name):

Enhances `source` support for OCI image URLs containing version tags by parsing the URL and passing parameters to kcl-lang/cli. Adds some helper functions to `pkg/source/oci` to better support parsing and reconstructing the URL.


#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [x] Affects user behaviors
- [x] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other


#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 


#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [x] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

Added additional integration tests to cover source URLs with the version specifier as well as non-existing versions.