### PR TITLE
test(edit): cover SourceToTempEntry, resource wrapping and YAML-to-KCL value conversion

### DIFF
--- a/pkg/edit/bootstrap_test.go
+++ b/pkg/edit/bootstrap_test.go
@@ -1,0 +1,124 @@
+package edit
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+func TestSourceToTempEntryInlineCode(t *testing.T) {
+	const code = `a = 1`
+	entry, err := SourceToTempEntry(code)
+	if err != nil {
+		t.Fatalf("SourceToTempEntry() error = %v", err)
+	}
+	defer KCLEntryOriginTmpDirCleanup(entry)
+
+	if entry.tmpDir == "" {
+		t.Fatal("inline code should be materialized into a temp dir, got empty tmpDir")
+	}
+	if filepath.Base(entry.source) != "prog.k" {
+		t.Errorf("inline code should be written to prog.k, got %q", entry.source)
+	}
+	content, err := os.ReadFile(entry.source)
+	if err != nil {
+		t.Fatalf("reading generated entry file: %v", err)
+	}
+	if string(content) != code {
+		t.Errorf("entry file content = %q, want %q", string(content), code)
+	}
+}
+
+func TestSourceToTempEntryPassthroughSources(t *testing.T) {
+	abs, err := filepath.Abs("testdata")
+	if err != nil {
+		t.Fatalf("resolving abs path: %v", err)
+	}
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{"oci", "oci://ghcr.io/kcl-lang/set-annotations"},
+		{"oci_with_tag", "oci://ghcr.io/kcl-lang/set-annotations:0.1.0"},
+		{"relative_local", "./main.k"},
+		{"absolute_local", abs},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry, err := SourceToTempEntry(tt.src)
+			if err != nil {
+				t.Fatalf("SourceToTempEntry() error = %v", err)
+			}
+			defer KCLEntryOriginTmpDirCleanup(entry)
+
+			// OCI and local sources are consumed in place, so they must not be
+			// copied into a temp dir nor rewritten.
+			if entry.source != tt.src {
+				t.Errorf("source = %q, want it passed through unchanged as %q", entry.source, tt.src)
+			}
+			if entry.tmpDir != "" {
+				t.Errorf("tmpDir = %q, want empty (no temp dir for in-place sources)", entry.tmpDir)
+			}
+		})
+	}
+}
+
+func TestKCLEntryOriginTmpDirCleanup(t *testing.T) {
+	entry, err := SourceToTempEntry(`a = 1`)
+	if err != nil {
+		t.Fatalf("SourceToTempEntry() error = %v", err)
+	}
+	tmpDir := entry.tmpDir
+
+	KCLEntryOriginTmpDirCleanup(entry)
+	if _, err := os.Stat(tmpDir); !os.IsNotExist(err) {
+		t.Errorf("temp dir %q still exists after cleanup", tmpDir)
+	}
+	// Cleanup must stay safe when the dir is already gone or was never created.
+	KCLEntryOriginTmpDirCleanup(entry)
+	KCLEntryOriginTmpDirCleanup(&KCLEntryOrigin{source: "oci://example.com/pkg"})
+}
+
+func TestToKCLValueString(t *testing.T) {
+	node, err := yaml.Parse(`
+replicas: 2
+name: nginx
+ports:
+- 80
+- 443
+`)
+	if err != nil {
+		t.Fatalf("parsing yaml: %v", err)
+	}
+	got, err := ToKCLValueString(node, emptyConfig)
+	if err != nil {
+		t.Fatalf("ToKCLValueString() error = %v", err)
+	}
+	for _, want := range []string{`"replicas":2`, `"name":"nginx"`, `"ports":[80,443]`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("ToKCLValueString() = %s, want it to contain %s", got, want)
+		}
+	}
+}
+
+func TestToKCLValueStringNilFallsBackToDefault(t *testing.T) {
+	node, err := yaml.Parse(`items: []`)
+	if err != nil {
+		t.Fatalf("parsing yaml: %v", err)
+	}
+	// Looking up a missing field yields a nil RNode, which must produce the default.
+	missing, err := node.Pipe(yaml.Lookup("functionConfig", "spec", "params"))
+	if err != nil {
+		t.Fatalf("lookup error: %v", err)
+	}
+	got, err := ToKCLValueString(missing, emptyConfig)
+	if err != nil {
+		t.Fatalf("ToKCLValueString() error = %v", err)
+	}
+	if got != emptyConfig {
+		t.Errorf("ToKCLValueString() = %q, want default %q", got, emptyConfig)
+	}
+}

--- a/pkg/edit/wraper_test.go
+++ b/pkg/edit/wraper_test.go
@@ -1,0 +1,199 @@
+package edit
+
+import (
+	"testing"
+
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+func mustParse(t *testing.T, s string) *yaml.RNode {
+	t.Helper()
+	node, err := yaml.Parse(s)
+	if err != nil {
+		t.Fatalf("parsing yaml: %v", err)
+	}
+	return node
+}
+
+const kclRunFnCfg = `
+apiVersion: krm.kcl.dev/v1alpha1
+kind: KCLRun
+metadata:
+  name: set-annotation
+spec:
+  source: |
+    a = 1
+`
+
+func TestWrapResourcesFiltersOutKCLRun(t *testing.T) {
+	nodes := []*yaml.RNode{
+		mustParse(t, "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: nginx\n"),
+		mustParse(t, kclRunFnCfg),
+		mustParse(t, "apiVersion: v1\nkind: Service\nmetadata:\n  name: svc\n"),
+	}
+	out, err := WrapResources(nodes, nil)
+	if err != nil {
+		t.Fatalf("WrapResources() error = %v", err)
+	}
+	if got := out.GetApiVersion(); got != kio.ResourceListAPIVersion {
+		t.Errorf("apiVersion = %q, want %q", got, kio.ResourceListAPIVersion)
+	}
+	if got := out.GetKind(); got != kio.ResourceListKind {
+		t.Errorf("kind = %q, want %q", got, kio.ResourceListKind)
+	}
+
+	items, err := out.Pipe(yaml.Lookup("items"))
+	if err != nil {
+		t.Fatalf("lookup items: %v", err)
+	}
+	elems, err := items.Elements()
+	if err != nil {
+		t.Fatalf("items.Elements(): %v", err)
+	}
+	// The KCLRun resource is the function config, not an input resource, so it
+	// must not be handed back to the KCL program as an item.
+	if len(elems) != 2 {
+		t.Fatalf("len(items) = %d, want 2 (KCLRun must be filtered out)", len(elems))
+	}
+	for _, e := range elems {
+		if e.GetKind() == "KCLRun" {
+			t.Error("KCLRun leaked into items")
+		}
+	}
+}
+
+func TestWrapResourcesSetsFunctionConfig(t *testing.T) {
+	nodes := []*yaml.RNode{
+		mustParse(t, "apiVersion: v1\nkind: Service\nmetadata:\n  name: svc\n"),
+	}
+	fc := mustParse(t, kclRunFnCfg)
+
+	out, err := WrapResources(nodes, fc)
+	if err != nil {
+		t.Fatalf("WrapResources() error = %v", err)
+	}
+	got, err := out.Pipe(yaml.Lookup("functionConfig", "metadata", "name"))
+	if err != nil {
+		t.Fatalf("lookup functionConfig: %v", err)
+	}
+	if got.IsNil() {
+		t.Fatal("functionConfig was not set on the resource list")
+	}
+	if name := yaml.GetValue(got); name != "set-annotation" {
+		t.Errorf("functionConfig.metadata.name = %q, want %q", name, "set-annotation")
+	}
+}
+
+func TestWrapResourcesEmptyInput(t *testing.T) {
+	out, err := WrapResources(nil, nil)
+	if err != nil {
+		t.Fatalf("WrapResources() error = %v", err)
+	}
+	items, err := out.Pipe(yaml.Lookup("items"))
+	if err != nil {
+		t.Fatalf("lookup items: %v", err)
+	}
+	elems, err := items.Elements()
+	if err != nil {
+		t.Fatalf("items.Elements(): %v", err)
+	}
+	if len(elems) != 0 {
+		t.Errorf("len(items) = %d, want 0", len(elems))
+	}
+}
+
+func TestUnwrapResourcesEmpty(t *testing.T) {
+	outs, fc, err := UnwrapResources(nil)
+	if err != nil {
+		t.Fatalf("UnwrapResources() error = %v", err)
+	}
+	if len(outs) != 0 {
+		t.Errorf("len(outs) = %d, want 0", len(outs))
+	}
+	if fc != nil {
+		t.Errorf("functionConfig = %v, want nil", fc)
+	}
+}
+
+func TestUnwrapResourcesBareResource(t *testing.T) {
+	// A single node that is not a ResourceList has no `items`, so it is
+	// returned as-is rather than being treated as an empty list.
+	in := []*yaml.RNode{
+		mustParse(t, "apiVersion: v1\nkind: Service\nmetadata:\n  name: svc\n"),
+	}
+	outs, _, err := UnwrapResources(in)
+	if err != nil {
+		t.Fatalf("UnwrapResources() error = %v", err)
+	}
+	if len(outs) != 1 {
+		t.Fatalf("len(outs) = %d, want 1", len(outs))
+	}
+	if got := outs[0].GetKind(); got != "Service" {
+		t.Errorf("kind = %q, want Service", got)
+	}
+}
+
+func TestUnwrapResourcesResourceList(t *testing.T) {
+	in := []*yaml.RNode{
+		mustParse(t, `
+apiVersion: config.kubernetes.io/v1
+kind: ResourceList
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: nginx
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: svc
+functionConfig:
+  apiVersion: krm.kcl.dev/v1alpha1
+  kind: KCLRun
+  metadata:
+    name: set-annotation
+`),
+	}
+	outs, fc, err := UnwrapResources(in)
+	if err != nil {
+		t.Fatalf("UnwrapResources() error = %v", err)
+	}
+	if len(outs) != 2 {
+		t.Fatalf("len(outs) = %d, want 2", len(outs))
+	}
+	if fc == nil || fc.GetKind() != "KCLRun" {
+		t.Errorf("functionConfig = %v, want a KCLRun node", fc)
+	}
+}
+
+func TestWrapUnwrapRoundTrip(t *testing.T) {
+	nodes := []*yaml.RNode{
+		mustParse(t, "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: nginx\n"),
+		mustParse(t, "apiVersion: v1\nkind: Service\nmetadata:\n  name: svc\n"),
+	}
+	wrapped, err := WrapResources(nodes, nil)
+	if err != nil {
+		t.Fatalf("WrapResources() error = %v", err)
+	}
+	outs, _, err := UnwrapResources([]*yaml.RNode{wrapped})
+	if err != nil {
+		t.Fatalf("UnwrapResources() error = %v", err)
+	}
+	if len(outs) != len(nodes) {
+		t.Fatalf("round trip changed resource count: got %d, want %d", len(outs), len(nodes))
+	}
+	for i := range nodes {
+		want, err := nodes[i].String()
+		if err != nil {
+			t.Fatalf("marshalling input %d: %v", i, err)
+		}
+		got, err := outs[i].String()
+		if err != nil {
+			t.Fatalf("marshalling output %d: %v", i, err)
+		}
+		if got != want {
+			t.Errorf("round trip changed resource %d:\ngot:\n%s\nwant:\n%s", i, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
pkg/edit (resource-list envelope wrapping + inline-KCL sandbox) carried no tests. pkg/kio already received `TestFilter_MultipleKCLRun_Regression` via #246, so this PR scopes itself to pkg/edit only.

## What it covers

- **SourceToTempEntry**: inline code materialised to `prog.k` in a temp dir with original bytes preserved; OCI / OCI-with-tag / relative / absolute local paths returned in place (no temp dir, no rewrite).
- **KCLEntryOriginTmpDirCleanup**: removes the sandbox and is idempotent on already-cleaned entries and entries that never opened one.
- **ToKCLValueString**: marshals a populated RNode to JSON-shaped KCL option value; falls back to the supplied default when the node is nil (the path `constructOptions` relies on for missing params).
- **WrapResources**: filters KCLRun out of `items`, sets `functionConfig` when supplied, empty `items` for empty input.
- **UnwrapResources**: returns a single node as-is when input is not a ResourceList, unwraps items + functionConfig from a ResourceList, empty slice for empty input.
- **Round trip**: `WrapResources` then `UnwrapResources` preserves each resource byte for byte.

## Not covered

- `pkg/kio` is already covered by `TestFilter_MultipleKCLRun_Regression` (#246).
- `pkg/api` and `pkg/api/v1alpha1` only hold constants and data structs; tests would restate the source.
- `pkg/edit.LoadDepListFromConfig` and `RunKCLWithConfig` are network-bound and deferred to a follow-up.

## Coverage
- pkg/edit: `0%` -> `27.4%`

## Verification
```
go test ./pkg/edit/...
ok      kcl-lang.io/krm-kcl/pkg/edit    0.554s  coverage: 27.4% of statements
```
Sanity-checked by mutating the KCLRun filter in `WrapResources` (removed the `continue`): `TestWrapResourcesFiltersOutKCLRun` correctly fails with `len(items) = 3, want 2`.

Signed-off-by: Peefy <xpf6677@163.com>