### PR TITLE
test(engine): probe cluster reachability instead of gating on GOOS

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,13 +25,13 @@ jobs:
         with:
           version: "v0.31.0"
 
-      - name: Kubernetes Testing
+      - name: Wait for kind cluster
         if: matrix.os == 'ubuntu-latest'
         run: |
-          kubectl cluster-info
-          kubectl get pods -n kube-system
-          echo "current-context:" $(kubectl config current-context)
-          echo "environment-kubeconfig:" ${KUBECONFIG}
+          # helm/kind-action brings up a kind cluster but races against the
+          # next step; wait for it to be Ready so TestEngineApplyAll does
+          # not flake on the very first call.
+          kubectl wait --for=condition=Ready nodes --all --timeout=120s
 
       - name: Unit test
         run: make test

--- a/pkg/kube/engine/apply_test.go
+++ b/pkg/kube/engine/apply_test.go
@@ -2,46 +2,66 @@ package engine
 
 import (
 	"context"
-	"runtime"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"kcl-lang.io/krm-kcl/pkg/kube"
 )
 
+// newEngineForTest returns an Engine wired to whatever cluster the ambient
+// kubeconfig points at, skipping the test when no cluster is reachable.
+//
+// Availability is probed with a real (cheap) API call rather than inferred
+// from the host OS: a kubeconfig can be absent, stale, or point at a cluster
+// that is down on any platform, and in those cases the test has nothing to
+// assert.
+func newEngineForTest(t *testing.T) *Engine {
+	t.Helper()
+
+	engine, err := NewDefaultEngine()
+	if err != nil {
+		t.Skipf("skipping: no usable kubeconfig (%v)", err)
+	}
+	gvr := schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}
+	if _, err := engine.Client().Resource(gvr).List(context.Background(), metav1.ListOptions{Limit: 1}); err != nil {
+		t.Skipf("skipping: cluster is not reachable (%v)", err)
+	}
+	return engine
+}
+
 func TestEngineApplyAll(t *testing.T) {
-	if runtime.GOOS == "linux" {
-		ctx := context.TODO()
-		objects := []*unstructured.Unstructured{
-			{
-				Object: map[string]interface{}{
-					"apiVersion": "apps/v1",
-					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
-						"name":      "my-deployment",
-						"namespace": "default",
+	ctx := context.TODO()
+	objects := []*unstructured.Unstructured{
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name":      "my-deployment",
+					"namespace": "default",
+				},
+				"spec": map[string]interface{}{
+					"selector": map[string]interface{}{
+						"matchLabels": map[string]interface{}{
+							"app": "my-app",
+						},
 					},
-					"spec": map[string]interface{}{
-						"selector": map[string]interface{}{
-							"matchLabels": map[string]interface{}{
+					"template": map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"labels": map[string]interface{}{
 								"app": "my-app",
 							},
 						},
-						"template": map[string]interface{}{
-							"metadata": map[string]interface{}{
-								"labels": map[string]interface{}{
-									"app": "my-app",
-								},
-							},
-							"spec": map[string]interface{}{
-								"containers": []interface{}{
-									map[string]interface{}{
-										"name":  "my-container",
-										"image": "nginx:latest",
-										"ports": []interface{}{
-											map[string]interface{}{
-												"containerPort": int64(80),
-											},
+						"spec": map[string]interface{}{
+							"containers": []interface{}{
+								map[string]interface{}{
+									"name":  "my-container",
+									"image": "nginx:latest",
+									"ports": []interface{}{
+										map[string]interface{}{
+											"containerPort": int64(80),
 										},
 									},
 								},
@@ -50,30 +70,31 @@ func TestEngineApplyAll(t *testing.T) {
 					},
 				},
 			},
-			{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "Service",
-					"metadata": map[string]interface{}{
-						"name":      "my-service",
-						"namespace": "default",
+		},
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata": map[string]interface{}{
+					"name":      "my-service",
+					"namespace": "default",
+				},
+				"spec": map[string]interface{}{
+					"selector": map[string]interface{}{
+						"app": "my-app",
 					},
-					"spec": map[string]interface{}{
-						"selector": map[string]interface{}{
-							"app": "my-app",
-						},
-						"ports": []interface{}{
-							map[string]interface{}{
-								"protocol":   "TCP",
-								"port":       int64(80),
-								"targetPort": int64(8080),
-							},
+					"ports": []interface{}{
+						map[string]interface{}{
+							"protocol":   "TCP",
+							"port":       int64(80),
+							"targetPort": int64(8080),
 						},
 					},
 				},
 			},
-		}
-		crd, err := kube.YamlByteToUnstructured([]byte(`
+		},
+	}
+	crd, err := kube.YamlByteToUnstructured([]byte(`
 {
 	"apiVersion": "apiextensions.k8s.io/v1",
 	"kind": "CustomResourceDefinition",
@@ -112,31 +133,34 @@ func TestEngineApplyAll(t *testing.T) {
 	}
 }
 `))
-		if err != nil {
-			t.Errorf("Generate CRD error: %v", err)
-		}
-		objects = append(objects, crd)
-		engine, err := NewDefaultEngine()
-		if err != nil {
-			t.Errorf("New default engine error: %v", err)
-		}
-		// Execute
-		status, err := engine.ApplyAll(ctx, objects, &ApplyOptions{})
-		// Verify
-		if err != nil {
-			t.Errorf("Apply returned unexpected error: %v", err)
-		}
-		if status != nil && len(status.Entries) != len(objects) {
-			t.Errorf("Apply returned unexpected number of status entries: got %d, want %d", len(status.Entries), len(objects))
-		}
-		// Double Execute
-		status, err = engine.ApplyAll(ctx, objects, &ApplyOptions{})
-		// Double Verify
-		if err != nil {
-			t.Errorf("Apply returned unexpected error: %v", err)
-		}
-		if status != nil && len(status.Entries) != len(objects) {
-			t.Errorf("Apply returned unexpected number of status entries: got %d, want %d", len(status.Entries), len(objects))
-		}
+	if err != nil {
+		t.Fatalf("Generate CRD error: %v", err)
+	}
+	objects = append(objects, crd)
+
+	engine := newEngineForTest(t)
+
+	// Execute
+	status, err := engine.ApplyAll(ctx, objects, &ApplyOptions{})
+	// Verify
+	if err != nil {
+		t.Fatalf("Apply returned unexpected error: %v", err)
+	}
+	if status == nil {
+		t.Fatal("Apply returned nil status, want one entry per object")
+	}
+	if len(status.Entries) != len(objects) {
+		t.Errorf("Apply returned unexpected number of status entries: got %d, want %d", len(status.Entries), len(objects))
+	}
+	// Double Execute: applying the same objects again must be idempotent.
+	status, err = engine.ApplyAll(ctx, objects, &ApplyOptions{})
+	if err != nil {
+		t.Fatalf("Apply returned unexpected error: %v", err)
+	}
+	if status == nil {
+		t.Fatal("Re-apply returned nil status, want one entry per object")
+	}
+	if len(status.Entries) != len(objects) {
+		t.Errorf("Apply returned unexpected number of status entries: got %d, want %d", len(status.Entries), len(objects))
 	}
 }


### PR DESCRIPTION
## Summary
`TestEngineApplyAll` had two silent-failure modes that hid real bugs in the kube engine and made CI flaky.

## What was wrong

1. **`if runtime.GOOS == "linux"` gate.** On macOS / Windows the test body never ran. Worse, on Linux the test was reachable even when no cluster was available: `NewDefaultEngine()` would fail and surface as `t.Errorf("New default engine error: ...")` — indistinguishable from a real regression. A wrong kubeconfig, a stale one, or a crashed kind cluster all looked the same as a bug in the engine.

2. **`if status != nil && len(...)` guard.** This short-circuited whenever `ApplyAll` returned `(nil, nil)` — a path the engine can take when no objects are passed. The test was happy to see zero entries.

## What it does now

- Replaces the OS check with a real connectivity probe: try a `namespaces` list with `Limit: 1`, skip with an explanatory message if it fails. macOS / Windows will now run the test against any cluster their kubeconfig points at; Linux without a reachable cluster will skip instead of failing misleadingly.
- Promotes `status == nil` from a silent short-circuit to an explicit `t.Fatal`.

## Workflow

The `Kubernetes Testing` step ran only `kubectl cluster-info` / `get pods` / `echo $KUBECONFIG` — read-only commands that don't actually wait for the cluster to be Ready. `helm/kind-action` returns as soon as the node container is up, but `kube-apiserver` isn't necessarily Ready yet, so the first call from `make test` flakes. Replace with `kubectl wait --for=condition=Ready nodes --all --timeout=120s`.

## Verified locally
- `go test ./pkg/kube/engine/...` compiles cleanly (skips on macOS due to probe).
- `go vet ./...` clean.

Signed-off-by: Peefy <xpf6677@163.com>