### PR TITLE
fix(oci): preserve registry port when parsing OCI source references

### DIFF
--- a/pkg/edit/bootstrap.go
+++ b/pkg/edit/bootstrap.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/hashicorp/go-getter"
 	"kcl-lang.io/krm-kcl/pkg/api"
@@ -86,11 +85,9 @@ func RunKCLWithConfig(name, src string, dependencies []string, resourceList *yam
 
 	// Configure the source
 	if source.IsOCI(entry.source) {
-		parts := strings.SplitN(source.TrimOCIPrefix(entry.source), ":", 2)
-		opts.Oci = source.OCIPrefix(parts[0])
-		if len(parts) > 1 {
-			opts.Tag = parts[1]
-		}
+		// Parse the OCI reference so that a registry port (e.g. ":7900") is
+		// not mistaken for the tag separator (see kcl-lang/krm-kcl issue #450).
+		opts.Oci, opts.Tag = source.ParseOCIReference(source.TrimOCIPrefix(entry.source))
 	} else {
 		// Everything else is treated as an entry.
 		opts.Entries = []string{entry.source}

--- a/pkg/source/oci.go
+++ b/pkg/source/oci.go
@@ -2,6 +2,7 @@ package source
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 )
 
@@ -22,4 +23,49 @@ func TrimOCIPrefix(src string) string {
 
 func OCIPrefix(src string) string {
 	return fmt.Sprintf("%s://%s", OCIScheme, src)
+}
+
+// ParseOCIReference parses an OCI reference (the part after "oci://") and
+// returns the cleaned reference URL together with the optional tag.
+//
+// The tag may appear in either of two places:
+//
+//   - As the last colon-separated segment of the repository path, e.g.
+//     "ghcr.io/kcl-lang/helloworld:0.1.0".
+//   - As a "?tag=X" query parameter, e.g. "host:7900/myapp?tag=0.1.0".
+//
+// When both are present, the query parameter wins.
+//
+// The port portion of the registry (":port" in "host:port") is preserved on
+// the returned reference. A naive split on ":" would mistake it for the tag
+// separator and break OCI URLs that target a non-default registry port (see
+// kcl-lang/krm-kcl issue #450).
+func ParseOCIReference(ref string) (string, string) {
+	// 1. Strip and parse any query string. A query tag, when present, takes
+	//    precedence over a path-suffix tag.
+	var queryTag string
+	if idx := strings.Index(ref, "?"); idx != -1 {
+		if q, err := url.ParseQuery(ref[idx+1:]); err == nil {
+			queryTag = q.Get("tag")
+		}
+		ref = ref[:idx]
+	}
+
+	// 2. Look for a ":tag" suffix on the path. We split at the first slash to
+	//    isolate the host (which may legitimately contain a ":port") from the
+	//    repository path, then take the last colon in the path as the tag.
+	var pathTag string
+	if pathIdx := strings.Index(ref, "/"); pathIdx != -1 {
+		pathPart := ref[pathIdx+1:]
+		if colon := strings.LastIndex(pathPart, ":"); colon != -1 {
+			pathTag = pathPart[colon+1:]
+			ref = ref[:pathIdx+1+colon]
+		}
+	}
+
+	tag := pathTag
+	if queryTag != "" {
+		tag = queryTag
+	}
+	return OCIPrefix(ref), tag
 }

--- a/pkg/source/oci_test.go
+++ b/pkg/source/oci_test.go
@@ -1,0 +1,91 @@
+package source
+
+import "testing"
+
+func TestParseOCIReference(t *testing.T) {
+	tests := []struct {
+		name     string
+		ref      string
+		wantURL  string
+		wantTag  string
+	}{
+		{
+			name:    "no tag",
+			ref:     "ghcr.io/kcl-lang/helloworld",
+			wantURL: "oci://ghcr.io/kcl-lang/helloworld",
+			wantTag: "",
+		},
+		{
+			name:    "path tag",
+			ref:     "ghcr.io/kcl-lang/set-annotations:0.1.1",
+			wantURL: "oci://ghcr.io/kcl-lang/set-annotations",
+			wantTag: "0.1.1",
+		},
+		{
+			name:    "path tag with multiple slashes",
+			ref:     "registry.example.com/team/sub/project:v1.2.3",
+			wantURL: "oci://registry.example.com/team/sub/project",
+			wantTag: "v1.2.3",
+		},
+		{
+			name:    "port without tag",
+			ref:     "host.docker.internal:7900/myapp",
+			wantURL: "oci://host.docker.internal:7900/myapp",
+			wantTag: "",
+		},
+		{
+			name:    "port with query tag",
+			ref:     "host.docker.internal:7900/myapp?tag=0.0.1",
+			wantURL: "oci://host.docker.internal:7900/myapp",
+			wantTag: "0.0.1",
+		},
+		{
+			name:    "port with path tag",
+			ref:     "host.docker.internal:7900/myapp:v1",
+			wantURL: "oci://host.docker.internal:7900/myapp",
+			wantTag: "v1",
+		},
+		{
+			name:    "query tag wins over path tag",
+			ref:     "host:7900/myapp:v1?tag=0.0.1",
+			wantURL: "oci://host:7900/myapp",
+			wantTag: "0.0.1",
+		},
+		{
+			name:    "empty tag value is ignored",
+			ref:     "ghcr.io/kcl-lang/helloworld?tag=",
+			wantURL: "oci://ghcr.io/kcl-lang/helloworld",
+			wantTag: "",
+		},
+		{
+			name:    "query with non-tag parameters is left alone",
+			ref:     "ghcr.io/kcl-lang/helloworld?other=value",
+			wantURL: "oci://ghcr.io/kcl-lang/helloworld",
+			wantTag: "",
+		},
+		{
+			name:    "port 443 with query tag",
+			ref:     "myregistry.example.com:443/kcl/foo?tag=1.2.3",
+			wantURL: "oci://myregistry.example.com:443/kcl/foo",
+			wantTag: "1.2.3",
+		},
+		{
+			name:    "host without path has no tag",
+			ref:     "host:7900",
+			wantURL: "oci://host:7900",
+			wantTag: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotURL, gotTag := ParseOCIReference(tt.ref)
+			if gotURL != tt.wantURL {
+				t.Errorf("ParseOCIReference(%q) url = %q, want %q", tt.ref, gotURL, tt.wantURL)
+			}
+			if gotTag != tt.wantTag {
+				t.Errorf("ParseOCIReference(%q) tag = %q, want %q", tt.ref, gotTag, tt.wantTag)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The OCI source parser introduced in #170 used `strings.SplitN(ref, ":", 2)` to separate the registry from the tag. This breaks OCI URLs that target a non-default registry port, because the colon in `host:port` is mistaken for the tag separator.

Before this fix, an input like `oci://host.docker.internal:7900/myapp?tag=0.0.1` produced:

* `opts.Oci  = "oci://host.docker.internal"` (port dropped)
* `opts.Tag  = "7900/myapp?tag=0.0.1"` (everything after the port colon)

The downstream `kpm` call then fails with `repository 'host.docker.internal' not found`. This regressed function-kcl in v0.12.0 and broke any local registry (`host.docker.internal:7900`) or cloud registry using `:443`.

## Fix

Replace the naive split with a new `source.ParseOCIReference` helper that:

1. Strips and parses any query string with `net/url.ParseQuery`, so `?tag=X` works.
2. Splits at the first `/` so the host (with port) stays intact.
3. Extracts the tag from the last `:` in the **path** only — not in the host.

When both a path-suffix tag and a `?tag=` are present, the query wins.

## Tests

Added `pkg/source/oci_test.go` with 11 cases covering:

* no tag, path tag, port without tag
* port with query tag, port with path tag
* query tag overriding path tag
* empty `?tag=` value ignored, non-tag query parameters left alone
* the existing PR #170 cases (unchanged behavior)

## Issue

Fixes crossplane-contrib/function-kcl#450.